### PR TITLE
Add support for multiple columns

### DIFF
--- a/src/schema/TableCompiler.ts
+++ b/src/schema/TableCompiler.ts
@@ -11,7 +11,7 @@ export class TableCompiler extends TableCompiler_MySQL {
       // @ts-ignore
       this.pushQuery({
         // @ts-ignore
-        sql: 'ALTER TABLE ' + this.tableName() + ' ADD ' + columns.sql.join(', '),
+        sql: 'ALTER TABLE ' + this.tableName() + ' ' + this.addColumnsPrefix + columns.sql.join(', '),
         bindings: columns.bindings
       });
     }

--- a/src/schema/TableCompiler.ts
+++ b/src/schema/TableCompiler.ts
@@ -6,6 +6,17 @@ export class TableCompiler extends TableCompiler_MySQL {
     super(client, builder);
   }
 
+  addColumns(columns) {
+    if (columns.sql.length > 0) {
+      // @ts-ignore
+      this.pushQuery({
+        // @ts-ignore
+        sql: 'ALTER TABLE ' + this.tableName() + ' ADD ' + columns.sql.join(', '),
+        bindings: columns.bindings
+      });
+    }
+  }
+
   index(columns, indexName, indexType) {
     // @ts-ignore
     this.client.logger.warn('Snowflake does not support the creation of indexes.');


### PR DESCRIPTION
The following migration:
```javascript
knex.schema.table('users', function (table) {
  table.string('first_name');
  table.string('last_name');
})
```

creates a query such as:
```sql
alter table "USERS" add "FIRST_NAME" varchar(255), **add** "LAST_NAME" varchar(255);
```

Whereas it should be:
```sql
alter table "USERS" add "FIRST_NAME" varchar(255), "LAST_NAME" varchar(255);
```